### PR TITLE
Migrate to SLES 15 SP4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY *.repo /etc/zypp/repos.d/
 ENV ADDITIONAL_MODULES sle-module-web-scripting
 
 RUN zypper refs && zypper --gpg-auto-import-keys refresh
-RUN zypper -n in apache2 php7 apache2-mod_php7 subversion-server subversion-tools enscript tar gzip sed diffutils
+RUN zypper -n in apache2 php8 apache2-mod_php8 subversion-server subversion-tools enscript tar gzip sed diffutils
 
 COPY apache2/ /etc/apache2/
 COPY htdocs/ /srv/www/htdocs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/suse/sle15:15.3.17.17.13
+FROM registry.suse.com/suse/sle15:15.4.27.8.3
 
 LABEL maintainer="thomas.foks@capgemini.com"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# subversion-httpd-sles15sp3
+# subversion-httpd-sles15sp4
 
 ![CI](https://github.com/tfoks/subversion-httpd-sles15sp3/actions/workflows/docker-image.yml/badge.svg)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) 
@@ -10,10 +10,7 @@
 
 # Supported tags and respective `Dockerfile` links
 
--	[`0.5`, `latest-prod`, `latest-dev`, `latest`](n.n.)
-
-`latest-prod` points to a production ready version
-`latest-dev` points to the latest development version and may be unstable
+t.b.d.
 
 # Quick reference (cont.)
 


### PR DESCRIPTION
The latest SLES 15 is at SP4 which introduces some breaking changes, e.g. moving to PHP8.

## Description
The base image will be from SP4 and moves to PHP8 as well.

## How Has This Been Tested?
Container builds and works as expected once finished.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
